### PR TITLE
Remove distDir config to fix dev/build conflict

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@
 const nextConfig = {
 	basePath: '',
 	output: 'export',
-	distDir: 'dist',
 	images: {
 		unoptimized: true,
 		remotePatterns: [


### PR DESCRIPTION
## Summary
- Remove `distDir: 'dist'` from `next.config.mjs` to fix conflict between Turbopack dev server and static export in Next.js 16
- Dev server and build were both writing to `dist/`, producing stale artifacts and inconsistent output
- Now uses Next.js defaults: `.next/` for build artifacts, `out/` for static export

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Verify `npm run dev` no longer writes to `dist/`
- [ ] Verify static export in `out/` matches dev output

🤖 Generated with [Claude Code](https://claude.com/claude-code)