### PR TITLE
feat(mobile): burger menu in navbar + passport photo in hero

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -15,8 +15,21 @@ export default function Hero() {
 			<div className="relative max-w-[1160px] mx-auto px-6 lg:px-12 pt-32 pb-24 w-full">
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
 					{/* Left: Content */}
-					<div>
-						<p className="inline-flex items-center gap-2 text-[11px] font-semibold tracking-[0.2em] uppercase text-secondaryLight mb-7">
+					<div className="relative">
+						{/* Passport-style photo — mobile only */}
+						<div className="absolute top-0 right-0 lg:hidden">
+							<div className="relative w-[72px] h-[88px] rounded-xl overflow-hidden border-2 border-secondaryLight/30 shadow-lg shadow-black/30">
+								<Image
+									src="/fro-pro.JPG"
+									alt="Fran&ccedil;ois Roget"
+									fill
+									className="object-cover object-top"
+									priority
+								/>
+							</div>
+						</div>
+
+						<p className="inline-flex items-center gap-2 text-[11px] font-semibold tracking-[0.2em] uppercase text-secondaryLight mb-7 pr-20 lg:pr-0">
 							<span className="w-7 h-0.5 bg-secondaryLight" />
 							{t.hero.eyebrow}
 						</p>

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import { useTranslation, type Locale } from '@/i18n/LanguageProvider';
 
@@ -7,6 +8,9 @@ const navSections = ['services', 'expertise', 'clients', 'articles'] as const;
 
 export default function Navbar() {
 	const { t, locale, setLocale } = useTranslation();
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+	const closeMenu = () => setIsMenuOpen(false);
 
 	return (
 		<nav className="fixed top-0 w-full z-50 bg-primaryDark/95 backdrop-blur-xl border-b border-white/[0.07]">
@@ -17,6 +21,8 @@ export default function Navbar() {
 					width={160}
 					height={44}
 				/>
+
+				{/* Desktop navigation */}
 				<div className="hidden md:flex items-center gap-9">
 					{navSections.map((id) => (
 						<a
@@ -52,7 +58,68 @@ export default function Navbar() {
 						{t.nav.contact}
 					</a>
 				</div>
+
+				{/* Mobile burger button */}
+				<button
+					onClick={() => setIsMenuOpen((v) => !v)}
+					className="md:hidden flex flex-col justify-center items-center w-10 h-10 gap-[5px] focus:outline-none"
+					aria-label="Menu"
+				>
+					<span
+						className={`block w-6 h-[2px] bg-white rounded-full transition-all duration-300 ${isMenuOpen ? 'translate-y-[7px] rotate-45' : ''}`}
+					/>
+					<span
+						className={`block w-6 h-[2px] bg-white rounded-full transition-all duration-300 ${isMenuOpen ? 'opacity-0' : ''}`}
+					/>
+					<span
+						className={`block w-6 h-[2px] bg-white rounded-full transition-all duration-300 ${isMenuOpen ? '-translate-y-[7px] -rotate-45' : ''}`}
+					/>
+				</button>
 			</div>
+
+			{/* Mobile menu panel */}
+			{isMenuOpen && (
+				<div className="md:hidden bg-primaryDark/98 backdrop-blur-xl border-t border-white/[0.07] px-6 py-6 flex flex-col gap-1">
+					{navSections.map((id) => (
+						<a
+							key={id}
+							href={`#${id}`}
+							onClick={closeMenu}
+							className="text-base font-medium text-white/70 tracking-[0.06em] uppercase py-3 border-b border-white/[0.06] hover:text-secondaryLight transition-colors"
+						>
+							{t.nav[id]}
+						</a>
+					))}
+
+					<a
+						href="#contact"
+						onClick={closeMenu}
+						className="mt-4 text-center text-[13px] font-bold text-white bg-gradient-to-br from-secondary to-secondaryLight px-6 py-3 rounded-md tracking-[0.04em] uppercase hover:opacity-90 transition-all"
+					>
+						{t.nav.contact}
+					</a>
+
+					{/* Language switcher */}
+					<div className="mt-5 pt-5 border-t border-white/[0.1] flex items-center justify-center gap-3 text-[13px] font-medium tracking-[0.08em]">
+						{(['fr', 'en'] as const).map((lang, i) => (
+							<span key={lang} className="flex items-center gap-3">
+								{i > 0 && (
+									<span className="text-white/20">|</span>
+								)}
+								<button
+									onClick={() => {
+										setLocale(lang as Locale);
+										closeMenu();
+									}}
+									className={`transition-colors uppercase ${locale === lang ? 'text-white' : 'text-white/40 hover:text-white/70'}`}
+								>
+									{lang}
+								</button>
+							</span>
+						))}
+					</div>
+				</div>
+			)}
 		</nav>
 	);
 }


### PR DESCRIPTION
- Navbar: add hamburger button (md:hidden) that toggles a full-width
  dropdown panel with nav links, contact CTA, and language switcher
  (FR/EN) at the bottom; menu closes on link click
- Hero: display a small passport-style photo (72×88px) absolutely
  positioned top-right of the first section on mobile (lg:hidden),
  with eyebrow text padded right to avoid overlap

https://claude.ai/code/session_01W4yEJvW6mgfjqB8YWuLHoj