### PR TITLE
Update tech stack: Replace Nx with Next.js

### DIFF
--- a/src/components/sections/Expertise.tsx
+++ b/src/components/sections/Expertise.tsx
@@ -47,7 +47,7 @@ const expertiseCards = [
 const statsData = [
 	{ value: '20+', key: 'years' as const },
 	{ value: '8+', key: 'clients' as const },
-	{ value: '4', key: 'articles' as const },
+	{ value: '5+', key: 'articles' as const },
 ];
 
 export default function Expertise() {

--- a/src/components/sections/TechStackBar.tsx
+++ b/src/components/sections/TechStackBar.tsx
@@ -1,9 +1,10 @@
 import { FaReact, FaJava, FaPhp } from 'react-icons/fa';
-import { SiTypescript } from 'react-icons/si';
+import { SiTypescript, SiNextdotjs } from 'react-icons/si';
 
 const techIcons = [
 	{ icon: <FaReact />, title: 'React' },
 	{ icon: <SiTypescript />, title: 'TypeScript' },
+	{ icon: <SiNextdotjs />, title: 'Next.js' },
 	{ icon: <FaJava />, title: 'Java' },
 	{ icon: <FaPhp />, title: 'PHP' },
 ];

--- a/src/data/site-data.ts
+++ b/src/data/site-data.ts
@@ -52,5 +52,5 @@ export const techStack = [
 	{ name: 'TypeScript', color: 'bg-[#3178C6]' },
 	{ name: 'Java', color: 'bg-[#ED8B00]' },
 	{ name: 'PHP', color: 'bg-[#777BB4]' },
-	{ name: 'Nx', color: 'bg-[#143055]' },
+	{ name: 'Next.js', color: 'bg-[#000000]' },
 ];


### PR DESCRIPTION
## Summary
Updated the tech stack to reflect Next.js as a core technology instead of Nx, and incremented the published articles count.

## Key Changes
- **TechStackBar component**: Added Next.js icon to the technology stack display alongside existing technologies (React, TypeScript, Java, PHP)
- **Expertise section**: Updated articles count from `4` to `5+` to reflect recent publications
- **Site data**: Replaced Nx with Next.js in the `techStack` array with appropriate branding color (black)

## Implementation Details
- Imported `SiNextdotjs` icon from `react-icons/si` library
- Next.js icon uses black background color (`bg-[#000000]`) matching the framework's branding
- All changes maintain consistency across the tech stack display components

https://claude.ai/code/session_01UZjuQ6QxjjjUdbDEjHCXLU