### PR TITLE
fix: rename proxy.ts to middleware.ts

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ function getLocaleFromPath(pathname: string): Locale {
 	return pathname.startsWith('/fr') ? 'fr' : 'en'
 }
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl
 
 	// Redirect root to preferred locale


### PR DESCRIPTION
## Summary

- Renames `src/proxy.ts` → `src/middleware.ts` so Next.js actually loads it (the framework only recognises the `middleware.ts` filename)
- Renames the exported function from `proxy` to `middleware` accordingly
- No logic changes — locale detection and redirect behaviour are identical

## Impact

Without this fix, the middleware was silently ignored: the root `/` redirect to the preferred locale and the `x-locale` header injection never ran in production.

## Test plan

- [ ] Navigate to `https://www.roget-concept.be/` — should redirect to `/fr` or `/en` based on `Accept-Language`
- [ ] Verify `x-locale` header is present on page requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)