### PR TITLE
feat(seo): add metadata and breadcrumb schema to privacy pages

### DIFF
--- a/src/app/[locale]/privacy/layout.tsx
+++ b/src/app/[locale]/privacy/layout.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+
+const BASE_URL = 'https://www.roget-concept.be'
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+	const { locale } = await params
+	const isFr = locale === 'fr'
+
+	return {
+		title: isFr
+			? 'Politique de confidentialité — Roget Concept'
+			: 'Privacy Policy — Roget Concept',
+		description: isFr
+			? 'Politique de confidentialité de Roget Concept SRL. Aucun cookie, aucune donnée personnelle collectée ou stockée.'
+			: 'Privacy policy for Roget Concept SRL. No cookies, no personal data collected or stored.',
+		alternates: {
+			canonical: `${BASE_URL}/${locale}/privacy`,
+			languages: {
+				en: `${BASE_URL}/en/privacy`,
+				fr: `${BASE_URL}/fr/privacy`,
+				'x-default': `${BASE_URL}/en/privacy`,
+			},
+		},
+	}
+}
+
+export default async function PrivacyLayout({
+	children,
+	params,
+}: {
+	children: ReactNode
+	params: Promise<{ locale: string }>
+}) {
+	const { locale } = await params
+	const isFr = locale === 'fr'
+
+	const breadcrumb = {
+		'@context': 'https://schema.org',
+		'@type': 'BreadcrumbList',
+		itemListElement: [
+			{
+				'@type': 'ListItem',
+				position: 1,
+				name: isFr ? 'Accueil' : 'Home',
+				item: `${BASE_URL}/${locale}`,
+			},
+			{
+				'@type': 'ListItem',
+				position: 2,
+				name: isFr ? 'Politique de confidentialité' : 'Privacy Policy',
+				item: `${BASE_URL}/${locale}/privacy`,
+			},
+		],
+	}
+
+	return (
+		<>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+			/>
+			{children}
+		</>
+	)
+}


### PR DESCRIPTION
## Summary

- New `src/app/[locale]/privacy/layout.tsx` server component
- Locale-aware `generateMetadata`: title, description, canonical URL, hreflang cross-links (`en` ↔ `fr` + `x-default`)
- `BreadcrumbList` JSON-LD schema (Home → Privacy Policy) injected in `<head>`

Previously the privacy pages had no SEO metadata, no canonical, and no cross-language links, which could cause duplicate content issues.

## Test plan

- [ ] `https://www.roget-concept.be/en/privacy` — check `<title>`, `<link rel="canonical">`, hreflang tags in source
- [ ] `https://www.roget-concept.be/fr/privacy` — same checks in French
- [ ] Validate breadcrumb schema via Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)