### PR TITLE
feat(seo): image sizes, sitemap hreflang, copy and config fixes

### DIFF
--- a/FULL-AUDIT-REPORT.md
+++ b/FULL-AUDIT-REPORT.md
@@ -1,0 +1,458 @@
+# Full SEO Audit Report — roget-concept.be
+**Audit Date:** 2026-04-01  
+**Stack:** Next.js 16 / React 19 / Tailwind 3 / Vercel  
+**Auditor:** Claude Code SEO Audit (7 specialist subagents)  
+**Pages in scope:** `/en`, `/fr`, `/en/privacy`, `/fr/privacy` + root `/`
+
+---
+
+## Executive Summary
+
+### Overall SEO Health Score: 69 / 100
+
+| Category | Weight | Score | Weighted |
+|----------|--------|-------|---------|
+| Technical SEO | 22% | 71 | 15.6 |
+| Content Quality | 23% | 73 | 16.8 |
+| On-Page SEO | 20% | 65 | 13.0 |
+| Schema / Structured Data | 10% | 62 | 6.2 |
+| Performance (CWV) | 10% | 72 | 7.2 |
+| AI Search Readiness | 10% | 72 | 7.2 |
+| Images | 5% | 58 | 2.9 |
+| **Total** | | | **68.9** |
+
+### Business Type Detected
+Freelance Senior Full Stack Developer & Architect — personal brand / professional services site.  
+Bilingual (EN/FR). 4 indexable pages. Single-page app with anchor-based navigation. Hosted on Vercel.
+
+### Top 5 Critical Issues
+1. `src/proxy.ts` is never loaded — middleware is broken, HTML `lang` attribute is always `"en"` even on `/fr`
+2. Privacy pages (`/en/privacy`, `/fr/privacy`) have no `generateMetadata` — missing canonical, hreflang, and unique title/description
+3. Every section component uses `'use client'` — visible content is JS-rendered, invisible in Google's first indexing wave
+4. `dateModified` in structured data and sitemap `lastmod` regenerate on every build — falsely signals continuous content freshness
+5. Profile photo `fro-pro.JPG` is 3 MB — LCP risk, excessive CDN bandwidth, slow cold-cache first render
+
+### Top 5 Quick Wins
+1. Rename `src/proxy.ts` → `src/middleware.ts` (2 minutes, fixes HTML lang + locale detection)
+2. Hardcode `dateModified` in `structured-data.ts` to a real ISO date string (5 minutes, fixes misleading freshness)
+3. Add `sizes` props to Hero and Paniers images (15 minutes, improves LCP srcset selection)
+4. Add `legalName`, `vatID`, `serviceType` to `ProfessionalService` schema (15 minutes, improves entity trust)
+5. Add registered office address to footer (5 minutes, legal compliance + trust signal)
+
+---
+
+## Technical SEO
+
+**Score: 71 / 100**
+
+### Critical
+
+#### 1. `src/proxy.ts` is not loaded as middleware
+Next.js only loads middleware from `src/middleware.ts` (or root `middleware.ts`). The file is named `proxy.ts` and the middleware manifest in `.next/server/middleware-manifest.json` confirms `"middleware": {}` — empty. Consequences:
+- `Accept-Language`-based locale detection never runs — root `/` always redirects to `/en`, ignoring browser language
+- `x-locale` header is never set → root layout fallback `?? 'en'` fires for every page
+- `/fr` pages are served with `<html lang="en">` in SSR HTML until JavaScript hydrates
+
+**Fix:** `mv src/proxy.ts src/middleware.ts` — no code changes needed.
+
+#### 2. Privacy pages have no metadata
+`src/app/[locale]/privacy/page.tsx` is `'use client'` with no `generateMetadata`. A client component cannot export metadata. No companion `layout.tsx` exists for the route segment. Result: `/en/privacy` and `/fr/privacy` inherit the root layout metadata with no overrides — no unique title, no description, no self-referencing canonical, no hreflang cross-link between the two language variants.
+
+**Fix:** Create `src/app/[locale]/privacy/layout.tsx` as a server component exporting `generateMetadata`.
+
+#### 3. All section content is `'use client'`
+Hero, Services, Expertise, Clients, Testimonials, Articles, AppShowcase, ContactCTA, Footer — all carry `'use client'`. The `[locale]/page.tsx` is a server component, but every child it renders is a client component. The HTML shell delivered to Googlebot's first indexing wave is nearly empty of visible body content.
+
+Root cause: every section calls `useTranslation()` (a React context hook), forcing them into client components. The locale is available from the URL segment at the server — it does not need to be read from context at render time.
+
+**Fix:** Pass translated strings as props from the server-side `[locale]/page.tsx`. Remove `useTranslation()` from static sections (Hero, Services, Expertise, Clients, Articles, ContactCTA, Footer). Only Navbar (burger/locale switcher) and Testimonials (carousel) need to remain client components.
+
+### High
+
+#### 4. Profile photo `fro-pro.JPG` is 3 MB
+Original Canon EOS 70D JPEG at 3648×2432 px. Largest rendered size: 420×520 px on desktop. Next.js Image Optimization resizes on-demand, but the 3 MB source means cold-cache first requests are slow and processing overhead is visible in Lighthouse.
+
+**Fix:** Resize to 840×1040 px WebP, targeting under 150 KB. Place in `/public/fro-pro.webp`.
+
+#### 5. PNG logos — 7 of 8 in PNG format
+`Be_Brussels.png` (281 KB), `Worldline.png` (83 KB), `Paynovate.png` (102 KB) are significantly over budget for 120×60 px display slots.
+
+**Fix:** Batch-convert PNG logos to WebP. Save ~450 KB in source assets.
+
+### Medium
+
+#### 6. `h1` is visually hidden (`sr-only`)
+`Hero.tsx:39` — the semantic H1 uses `sr-only`, while the large visible "François" display text uses a `<p>` tag. Google weights visible heading text more than off-screen text. The `sr-only` H1 is not hidden deliberately for keyword stuffing (content is legitimate), but it creates a disconnect worth monitoring.
+
+#### 7. `LanguageProvider` sets `document.documentElement.lang` client-side only
+`<html lang>` in SSR HTML is always `"en"` (fallback). Resolved automatically by fixing issue #1 (rename `proxy.ts`).
+
+#### 8. Structured data `@id` values reference root URL (a redirect)
+`structured-data.ts` uses `BASE_URL + '/'` for `ProfilePage.url` and all `@id` anchors. Root `/` is a server-side redirect to `/en`. The ProfilePage entity points to a URL that never resolves to a 200. On `/fr`, the schema claims `url: "/"` while canonical is `/fr`.
+
+**Fix:** Move structured data into `[locale]/layout.tsx` where locale is known; use `BASE_URL/[locale]` as the `ProfilePage` URL per language.
+
+### Low
+
+#### 9. IndexNow protocol not implemented
+No instant-indexing notification for Bing/Yandex on content updates.
+
+#### 10. `Anthropic-AI` user agent not in explicit allow list
+`robots.ts` already allows `*` + named bots. Adding `Anthropic-AI` is consistent with the explicit-allow strategy.
+
+### Passing Items
+- robots.txt: all major AI bots explicitly allowed ✓
+- HTTPS + www redirect (301) via `vercel.json` ✓
+- HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy ✓
+- hreflang on `/en` and `/fr`: symmetric EN/FR/x-default triplets ✓
+- OG + Twitter card metadata on all content pages ✓
+- Static generation (`generateStaticParams`) — best possible TTFB ✓
+- `sharp` installed — Next.js Image Optimization active ✓
+- Source maps disabled in production ✓
+- No external JS frameworks, no tag managers ✓
+
+---
+
+## Content Quality
+
+**Score: 74 / 100 (Content), 72 / 100 (E-E-A-T)**
+
+### E-E-A-T Breakdown
+
+| Signal | Score | Notes |
+|--------|-------|-------|
+| Experience | 16/20 | Strong client tenure data; missing measurable outcomes |
+| Expertise | 20/25 | Granular tech skills; no certifications mentioned |
+| Authoritativeness | 17/25 | Named clients + testimonials; no external press citations |
+| Trustworthiness | 19/30 | Legal entity present; missing physical address |
+
+### High
+
+#### 1. No individual service pages
+The Training service has zero keyword co-location between "training/workshop/courses" and "Belgium" in any paragraph text. A standalone `/en/services/training` with 800+ words would substantially improve ranking for "React training Belgium", "TypeScript workshop Belgium", etc.
+
+#### 2. Missing registered office address — legal compliance gap
+Belgian commercial law requires a registered business's office address on its website. VAT number (BTW BE 1008.928.573) is present but address is absent. This is simultaneously a legal gap and a QRG trustworthiness signal.
+
+#### 3. `dateModified` dynamically generated
+`structured-data.ts:13` — `new Date().toISOString().split('T')[0]` changes on every deploy. Google flags manipulated freshness signals as a trust issue.
+
+### Medium
+
+#### 4. Testimonials in JS carousel — limited AI accessibility
+All five testimonials are in a `'use client'` carousel with CSS `translateX`. Off-screen content may not be extracted by AI crawlers. These are the richest quotable third-party endorsements on the site.
+
+#### 5. "Pragmatic, no-nonsense solutions" appears verbatim twice
+In `hero.bioSub` and `services.consultancy.points[3]` — exact phrase repetition on the same page.
+
+#### 6. Training service has no CTA
+Neither service card contains a direct call-to-action. Users reading the Training card must scroll the full page to reach Contact.
+
+#### 7. "Belgium" keyword weak co-occurrence with services
+"Belgium" appears only 3 times on the EN page and never in the same sentence as "training", "workshop", "TypeScript", or "React".
+
+### Low
+
+#### 8. No education credentials on-site
+BSc in Computer Science (ESI Bruxelles, 2009) is public and a legitimate expertise signal — absent from the site.
+
+#### 9. "consultant/consultancy" absent from body paragraph copy
+Used in section/card titles but not in paragraph text where natural language signals are read.
+
+#### 10. No Terms of Service / General Conditions page
+For a professional services business, a T&C page is a minor trust gap per QRG transparency criteria.
+
+### Keyword Targeting Summary
+
+| Target Keyword | Status |
+|----------------|--------|
+| Freelance developer Belgium | Good |
+| Full stack developer Belgium | Good |
+| Software architect Belgium | Good |
+| React developer Belgium | Weak co-occurrence |
+| TypeScript consultant Belgium | Gap |
+| React training Belgium | Gap |
+| TypeScript workshop Belgium | Gap |
+| IT Consultancy Belgium | Partial |
+
+---
+
+## On-Page SEO
+
+**Score: 65 / 100**
+
+### Issues
+
+| Severity | Issue |
+|----------|-------|
+| Critical | Privacy pages: identical title + description to homepage (inherited, no override) |
+| Critical | Privacy pages: no self-referencing canonical URLs |
+| Critical | Privacy pages: no hreflang cross-links between EN and FR variants |
+| High | H1 is `sr-only` — not visible to users or given full weight by Google |
+| Medium | "Belgium" keyword underused in service descriptions |
+| Low | Article cards lack per-card author attribution |
+| Low | `consultant`/`consultancy` absent from body paragraph copy |
+
+### Passing Items
+- EN homepage: unique, keyword-rich title ✓
+- EN/FR: distinct meta descriptions in both languages ✓
+- Heading hierarchy: H1 → H2 → H3 logical ✓
+- Internal anchor navigation covers all key sections ✓
+- Footer: email, social links, legal entity clearly present ✓
+
+---
+
+## Schema / Structured Data
+
+**Score: 62 / 100**
+
+### Detected Schema (all pages, global `@graph`)
+- `ProfilePage` (`#webpage`)
+- `Person` (`#person`) — François Roget
+- `ProfessionalService` (`#business`)
+- `WebSite` (`#website`)
+- `ItemList` (5 Medium articles)
+
+### Critical
+
+#### C1. `dateModified` always equals today's date
+`new Date().toISOString()` at build time means every deployment resets it. Hardcode to last actual content change date.
+
+#### C2. ProfilePage `url` points to a redirect, not the canonical
+`url: BASE_URL + '/'` — root redirects to `/en`. The ProfilePage entity cannot be correctly associated with any crawlable canonical URL. The same global schema block appears on `/fr`, claiming `url: "/"` while canonical is `/fr`.
+
+### High
+
+#### H1. No `SoftwareApplication` schema for Paniers app
+App Store link, platform list, and feature set are present — a `SoftwareApplication` node with `applicationCategory`, `operatingSystem`, `downloadUrl`, and `offers` would make Paniers a named, citable product.
+
+#### H2. No `Review`/`AggregateRating` for testimonials
+Five named, attributed reviews with professional credentials exist in `site-data.ts` but are not exposed in structured data.
+
+#### H3. `ProfessionalService` missing `legalName`, `vatID`, `serviceType`
+Privacy page confirms: "Roget Concept SRL", "BTW BE 1008.928.573". These trust signals are not in the schema.
+
+### Medium
+
+#### M1. No `BreadcrumbList` on privacy pages
+A `Home > Privacy Policy` breadcrumb on `/en/privacy` and `/fr/privacy` would enable breadcrumb rich results.
+
+#### M2. Schema not localized per language URL
+Both `/en` and `/fr` receive identical schema. ProfilePage `url`, `inLanguage`, and `name` should reflect the current locale.
+
+#### M3. `PostalAddress` missing `addressLocality`
+Both `Person` and `ProfessionalService` have `addressCountry: 'BE'` only.
+
+#### M4. `ItemList` uses bare `url` on `ListItem` instead of `item` property
+Google recommends `ListItem.item` as a `Thing` with `@type`, `name`, and `url` for carousel rich result eligibility.
+
+#### M5. `Person.image` is a bare URL string, not `ImageObject`
+Upgrade to `ImageObject` with `width`, `height`, `url` for Knowledge Panel eligibility.
+
+### Low
+- `WebSite` missing `potentialAction` SearchAction
+- `ProfessionalService.sameAs` missing Medium profile
+- No `Service` nodes for IT Consultancy and Technical Training
+- No `WebPage` schema on privacy pages
+
+---
+
+## Performance (Core Web Vitals)
+
+**Score: 72 / 100**  
+**Estimated PageSpeed: 85–92 desktop / 65–78 mobile**
+
+### LCP (Likely: Needs Improvement on mobile)
+- LCP candidate: `fro-pro.JPG` (hero photo) on desktop; large decorative text on mobile
+- 2.9 MB source JPEG — cold cache first render is slow
+- `priority` prop correctly set ✓
+- `sizes` prop **missing** on both hero instances → browser requests incorrect srcset variant
+
+### CLS (Likely: Good)
+- All images use `fill` with explicit-dimension parent containers ✓
+- Font uses `font-display: swap` — FOUT possible; no `adjustFontFallback` configured
+- Testimonials carousel uses CSS `translateX` — no layout shift ✓
+
+### INP (Likely: Good in steady state, Medium risk before hydration)
+- Full client bundle hydration on every page
+- Static sections (Services, Expertise, etc.) could be RSC — unnecessary JS parse cost
+- No heavy event handlers; carousel properly cleaned up ✓
+
+### Key Findings
+
+| Issue | Severity | File |
+|-------|----------|------|
+| `fro-pro.JPG` 3 MB source | High | `/public/fro-pro.JPG` |
+| Missing `sizes` on hero images | Medium | `Hero.tsx:107,114` |
+| No `adjustFontFallback` | Medium | `layout.tsx` (font declaration) |
+| No `Cache-Control` for `/public` images | Low | `vercel.json` |
+| No `preconnect` for `miro.medium.com` | Low | `layout.tsx` |
+
+### Passing Items
+- Self-hosted font via `next/font/local` — no Google Fonts latency ✓
+- Static generation (SSG) for all locale routes — minimal TTFB ✓
+- `sharp` installed — WebP/AVIF serving active ✓
+- Only 3 external origins total ✓
+- No blocking third-party scripts ✓
+- Vercel Analytics / Speed Insights are deferred and non-blocking ✓
+
+---
+
+## AI Search Readiness (GEO)
+
+**Score: 72 / 100**
+
+### Platform Scores
+
+| Platform | Score | Notes |
+|----------|-------|-------|
+| Google AI Overviews | 6.5/10 | ProfilePage schema + meta clear; no SpeakableSpecification |
+| ChatGPT / ChatGPT Search | 6.0/10 | llms.txt good; testimonials in JS carousel |
+| Perplexity | 7.5/10 | Named clients + tenures = strong factual anchors |
+| Bing Copilot | 7.0/10 | OG complete; missing `legalName` in schema |
+
+### Strengths
+- robots.txt explicitly allows all major AI crawlers ✓
+- `llms.txt` present, well-formed, and structured ✓
+- Structured data injected server-side — visible without JS ✓
+- Named enterprise clients with tenure durations (Eurocontrol 9y, etc.) ✓
+- Legal entity (Roget Concept SRL, VAT) present ✓
+
+### Gaps
+
+#### High
+1. **Testimonials in JS carousel** — richest quotable content unreliable for AI extraction
+2. **No `SpeakableSpecification`** — Google AI Overviews and voice AI cannot identify optimal passages
+3. **No dedicated bio/about page** — no single canonical URL for "who is François Roget" queries
+
+#### Medium
+4. **Hero bio fragmented** — split across 3 `<span>` elements; AI parsers may extract disconnected passages
+5. **llms.txt missing RSL 1.0 license** — some AI systems skip citation without explicit license
+6. **Client tenures missing from llms.txt** — names only, no tenure data
+
+#### Low
+7. **No YouTube presence** — highest-known correlation signal for AI citation (0.737)
+8. **No Wikipedia / Wikidata entry** — prevents canonical entity resolution by AI knowledge graphs
+9. **No Reddit/community presence** attributable to the name
+
+---
+
+## Images
+
+**Score: 58 / 100**
+
+### Critical
+- `fro-pro.JPG`: 3.03 MB, 3648×2432 px for a 420×520 display slot
+- `paniers-icon.png`: 655 KB PNG for a ~240 px display slot
+
+### High
+- `sizes` prop missing on hero headshot (both instances) and Paniers icon
+- 7 of 8 client logos in PNG format (only Tunz.webp is modern format)
+- Alt text on headshot: `"François Roget"` — misses keyword opportunity
+- `Be_Brussels.png`: 281 KB for a 120×60 slot
+
+### Medium
+- OG image is a photo-based JPEG with no visible branding — poor link preview performance
+- `Person.image` in schema is a 3 MB JPEG URL — crawlers fetching this schema image hit the unoptimized file
+- Article `sizes` prop uses `25vw` at 1024px+ (actual rendered size is ~33vw in 3-column grid)
+- No separate OG image for FR locale
+
+### Low
+- No `manifest.json` for PWA/Android home screen icons
+- Logo filenames: `Be_Brussels.png` uses underscore (minor, no practical impact)
+
+### Passing Items
+- `next/image` used consistently throughout ✓
+- `priority` on both hero photo instances ✓
+- `sizes` on article cards ✓
+- OG image: 1200×630, 65 KB ✓
+- SVG favicon + ICO fallback + apple-touch-icon ✓
+- Article thumbnails: WebP via Medium CDN ✓
+
+---
+
+## Sitemap
+
+**Score: 85 / 100**
+
+### URL Coverage
+
+| URL | In Sitemap | Status |
+|-----|------------|--------|
+| `/` | No | Correct — redirects to `/en`, redirect sources excluded |
+| `/en` | Yes ✓ | 200 |
+| `/fr` | Yes ✓ | 200 |
+| `/privacy` | No | Correct — redirects to `/en/privacy` |
+| `/en/privacy` | Yes ✓ | 200 |
+| `/fr/privacy` | Yes ✓ | 200 |
+
+### Issues
+
+| Severity | Issue |
+|----------|-------|
+| High | `lastmod` is `new Date()` at request time — changes on every fetch, Google ignores it |
+| Medium | `changefreq` and `priority` are present — Google officially ignores both, remove clutter |
+| Low | No `<xhtml:link>` hreflang annotations in sitemap (HTML `<head>` handles it — not a bug, but sitemap-level hreflang is more reliable) |
+
+### Recommended Fix (`src/app/sitemap.ts`)
+
+```ts
+import { MetadataRoute } from 'next'
+const BASE_URL = 'https://www.roget-concept.be'
+const HOME_LASTMOD = new Date('2026-03-01')
+const PRIVACY_LASTMOD = new Date('2026-03-01')
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `${BASE_URL}/en`,
+      lastModified: HOME_LASTMOD,
+      alternates: { languages: { en: `${BASE_URL}/en`, fr: `${BASE_URL}/fr`, 'x-default': `${BASE_URL}/en` } },
+    },
+    {
+      url: `${BASE_URL}/fr`,
+      lastModified: HOME_LASTMOD,
+      alternates: { languages: { en: `${BASE_URL}/en`, fr: `${BASE_URL}/fr`, 'x-default': `${BASE_URL}/en` } },
+    },
+    {
+      url: `${BASE_URL}/en/privacy`,
+      lastModified: PRIVACY_LASTMOD,
+      alternates: { languages: { en: `${BASE_URL}/en/privacy`, fr: `${BASE_URL}/fr/privacy` } },
+    },
+    {
+      url: `${BASE_URL}/fr/privacy`,
+      lastModified: PRIVACY_LASTMOD,
+      alternates: { languages: { en: `${BASE_URL}/en/privacy`, fr: `${BASE_URL}/fr/privacy` } },
+    },
+  ]
+}
+```
+
+---
+
+## Appendix: Source Files Referenced
+
+| File | Issues |
+|------|--------|
+| `src/proxy.ts` | Rename to `middleware.ts` |
+| `src/app/layout.tsx` | Font fallback, preconnect hints, global schema injection |
+| `src/app/structured-data.ts` | dateModified, ProfilePage url, add Review/SoftwareApplication nodes |
+| `src/app/sitemap.ts` | lastmod, changefreq, priority, add alternates |
+| `src/app/robots.ts` | Add `Anthropic-AI` token |
+| `src/app/[locale]/layout.tsx` | Move schema here for locale-awareness |
+| `src/app/[locale]/privacy/page.tsx` | Create companion layout.tsx with generateMetadata |
+| `src/components/sections/Hero.tsx` | RSC conversion, sizes prop, alt text |
+| `src/components/sections/Testimonials.tsx` | Consider static HTML rendering |
+| `src/components/sections/Services.tsx` | RSC conversion, CTA addition, Belgium keyword |
+| `src/components/sections/Articles.tsx` | RSC conversion, fix sizes (25vw→33vw) |
+| `src/components/sections/Clients.tsx` | RSC conversion, add sizes="120px" |
+| `src/components/sections/AppShowcase.tsx` | Add sizes, improve alt text |
+| `src/i18n/locales/en.ts` | Remove duplicate "Pragmatic, no-nonsense solutions" |
+| `src/data/site-data.ts` | Source for Review schema data |
+| `vercel.json` | Add Cache-Control for public images |
+| `public/fro-pro.JPG` | Replace with WebP under 150 KB |
+| `public/paniers-icon.png` | Replace with WebP under 80 KB |
+| `public/logos/Be_Brussels.png` | Convert to WebP |
+| `public/logos/Worldline.png` | Convert to WebP |
+| `public/logos/Paynovate.png` | Convert to WebP |
+| `public/llms.txt` | Add RSL 1.0 license, add client tenures |

--- a/seo-tasks/H1-high-hero-photo-optimize.md
+++ b/seo-tasks/H1-high-hero-photo-optimize.md
@@ -1,0 +1,17 @@
+# H1 — Optimiser la photo de profil `fro-pro.JPG`
+
+**Severity:** High  
+**Effort:** 15 minutes  
+**Files:** `public/fro-pro.JPG` → `public/fro-pro.webp`, `src/components/sections/Hero.tsx`
+
+## Problème
+
+`public/fro-pro.JPG` est un JPEG Canon EOS 70D original à 3648×2432 px, soit **3 MB**. La taille d'affichage max est 420×520 px (desktop). C'est le candidat LCP de la page.
+
+Même si Next.js Image Optimization redimensionne à la volée, le fichier source de 3 MB est chargé au premier hit cold-cache, ce qui ralentit le LCP.
+
+## Fix
+
+1. Exporter une version recadrée : **840×1040 px** (2× retina), format WebP, qualité 85, cible < 150 KB
+2. Placer le fichier dans `public/fro-pro.webp`
+3. Dans `src/components/sections/Hero.tsx`, remplacer les deux occurrences de `src="/fro-pro.JPG"` par `src="/fro-pro.webp"`

--- a/seo-tasks/H6-high-footer-address.md
+++ b/seo-tasks/H6-high-footer-address.md
@@ -1,0 +1,21 @@
+# H6 — Ajouter l'adresse du siège social dans le footer
+
+**Severity:** High  
+**Effort:** 10 minutes  
+**Files:** `src/i18n/locales/en.ts`, `src/i18n/locales/fr.ts`
+
+## Problème
+
+Le droit commercial belge (Code des sociétés et des associations) impose aux entreprises d'afficher leur adresse de siège social sur leur site web. Le numéro de TVA (BTW BE 1008.928.573) est bien présent, mais pas l'adresse.
+
+C'est à la fois une obligation légale et un signal de confiance selon les critères QRG (Quality Rater Guidelines) de Google.
+
+## Fix
+
+Ajouter l'adresse dans la ligne légale du footer, aux côtés du numéro de TVA. Exemple :
+
+```
+Roget Concept SRL — BTW BE 1008.928.573 — [Ville], Belgique
+```
+
+Mettre à jour les fichiers de traduction EN et FR en conséquence.

--- a/seo-tasks/H8-high-schema-locale-aware.md
+++ b/seo-tasks/H8-high-schema-locale-aware.md
@@ -1,0 +1,28 @@
+# H8 — Rendre le schema `ProfilePage` locale-aware
+
+**Severity:** High  
+**Effort:** 30–60 minutes  
+**Files:** `src/app/structured-data.ts`, `src/app/[locale]/layout.tsx`, `src/app/layout.tsx`
+
+## Problème
+
+Le schema structuré est défini comme une constante dans `structured-data.ts` et injecté dans le layout racine (`src/app/layout.tsx`). Il est donc identique sur `/en` et `/fr`.
+
+Problèmes concrets :
+- `ProfilePage.url` pointe vers `https://www.roget-concept.be/` (un redirect 307/308 vers `/en`), pas vers la canonical de la page
+- Sur `/fr`, le schema déclare `url: "/"` alors que la canonical est `/fr`
+- `ProfilePage.inLanguage` est `['en', 'fr']` sur les deux pages au lieu de `'en'` ou `'fr'` selon la locale
+
+## Fix
+
+1. Transformer `structuredData` en fonction dans `structured-data.ts` :
+   ```ts
+   export function getStructuredData(locale: 'en' | 'fr') { ... }
+   ```
+
+2. Déplacer l'injection du schema depuis `src/app/layout.tsx` vers `src/app/[locale]/layout.tsx` (où la locale est connue)
+
+3. Dans le nœud `ProfilePage` :
+   - `url` → `${BASE_URL}/${locale}`
+   - `'@id'` → `${BASE_URL}/${locale}#webpage`
+   - `inLanguage` → `locale`

--- a/seo-tasks/L10-low-terms-of-service.md
+++ b/seo-tasks/L10-low-terms-of-service.md
@@ -1,0 +1,19 @@
+# L10 — Créer une page Conditions Générales
+
+**Severity:** Low  
+**Effort:** 1–2 heures (rédaction)  
+
+## Problème
+
+Un site de services professionnels (IT Consultancy, formation) sans Conditions Générales est un gap de confiance mineur selon les Quality Rater Guidelines de Google (critère de transparence). Ce n'est pas un impact direct sur le ranking, mais c'est une bonne pratique pour un site commercial.
+
+## Fix
+
+Créer `/en/terms` et `/fr/terms` avec les Conditions Générales de Roget Concept SRL. À minima :
+- Objet des services
+- Conditions de paiement
+- Propriété intellectuelle
+- Limitation de responsabilité
+- Droit applicable (droit belge)
+
+Ajouter un lien dans le footer aux côtés du lien Privacy Policy.

--- a/seo-tasks/L11-low-og-image-branded.md
+++ b/seo-tasks/L11-low-og-image-branded.md
@@ -1,0 +1,23 @@
+# L11 — Concevoir une image OG avec branding
+
+**Severity:** Low  
+**Effort:** 1–2 heures (design)  
+**File:** `public/og-image.jpg`
+
+## Problème
+
+L'image OG actuelle est une photo sans texte ni logo visible. Quand le site est partagé sur LinkedIn, Slack ou WhatsApp, la preview ne montre pas de branding identifiable — c'est une opportunité de conversion manquée.
+
+## Spec recommandée
+
+- Dimensions : 1200×630 px
+- Fond : `#12122e` (couleur brand dark)
+- Logo Roget Concept en haut à gauche
+- Nom "François Roget" en blanc, gras, grande taille
+- Sous-titre : "Senior Full Stack Developer & Architect"
+- Accent teal `#00dbcb`
+- Optionnel : photo portrait en arrière-plan (opacité réduite)
+
+## Variantes
+
+Créer une version FR avec "Développeur Full Stack Senior & Architecte" pour `og-image-fr.jpg`, et déclarer chaque variante dans `[locale]/layout.tsx`.

--- a/seo-tasks/L2-low-indexnow.md
+++ b/seo-tasks/L2-low-indexnow.md
@@ -1,0 +1,26 @@
+# L2 — Implémenter IndexNow
+
+**Severity:** Low  
+**Effort:** 30 minutes  
+
+## Problème
+
+IndexNow permet de notifier instantanément Bing, Yandex et Naver lors de chaque mise à jour de contenu, sans attendre le prochain cycle de crawl. Non implémenté actuellement.
+
+Pour un site de 4 pages avec des mises à jour rares, l'impact est faible — mais le setup est simple et une fois en place, il bénéficie à chaque déploiement futur.
+
+## Fix
+
+1. Générer une clé IndexNow (une chaîne alphanumérique unique)
+2. Héberger `public/<clé>.txt` avec la clé comme contenu
+3. Ajouter un appel `POST` à `https://api.indexnow.org/indexnow` dans un Vercel deploy hook ou une GitHub Action de post-déploiement :
+   ```json
+   {
+     "host": "www.roget-concept.be",
+     "key": "<clé>",
+     "urlList": [
+       "https://www.roget-concept.be/en",
+       "https://www.roget-concept.be/fr"
+     ]
+   }
+   ```

--- a/seo-tasks/L3-low-education-credentials.md
+++ b/seo-tasks/L3-low-education-credentials.md
@@ -1,0 +1,19 @@
+# L3 — Ajouter les diplômes dans la section Expertise ou Hero
+
+**Severity:** Low  
+**Effort:** 10 minutes  
+**Files:** `src/i18n/locales/en.ts`, `src/i18n/locales/fr.ts`
+
+## Problème
+
+Un BSc in Computer Science (ESI Bruxelles, 2009) est une credential vérifiable publiquement — absente du site. Les credentials éducatifs sont un signal d'expertise (E-E-A-T) selon les Quality Rater Guidelines de Google.
+
+## Fix
+
+Ajouter la mention dans la section Expertise ou dans le bio Hero. Exemple :
+
+```
+BSc Computer Science — ESI Bruxelles (2009)
+```
+
+Peut être intégré dans une ligne "About" ou comme item dans la section Expertise.

--- a/seo-tasks/L5-low-schema-image-object.md
+++ b/seo-tasks/L5-low-schema-image-object.md
@@ -1,0 +1,22 @@
+# L5 — Upgrader `Person.image` en `ImageObject`
+
+**Severity:** Low  
+**Effort:** 5 minutes  
+**File:** `src/app/structured-data.ts`
+
+## Problème
+
+`Person.image` et `ProfessionalService.image` sont des chaînes URL nues (`https://...fro-pro.JPG`). Schema.org recommande un objet `ImageObject` avec `width`, `height` et `url` pour une meilleure éligibilité au Knowledge Panel Google.
+
+Note : dépend de H1 — attendre que `fro-pro.JPG` soit remplacé par une version optimisée avant de mettre à jour l'URL ici.
+
+## Fix
+
+```ts
+image: {
+  '@type': 'ImageObject',
+  url: `${BASE_URL}/fro-pro.webp`,
+  width: 840,
+  height: 1040,
+},
+```

--- a/seo-tasks/L7-low-schema-webpage-privacy.md
+++ b/seo-tasks/L7-low-schema-webpage-privacy.md
@@ -1,0 +1,25 @@
+# L7 — Ajouter un schema `WebPage` sur les pages privacy
+
+**Severity:** Low  
+**Effort:** 15 minutes  
+**File:** `src/app/[locale]/privacy/layout.tsx` (créé en C2)
+
+## Problème
+
+Les pages privacy héritent du schema global (`@graph`) du layout racine mais n'ont aucun nœud `WebPage` spécifique à leur URL. C'est une incohérence mineure par rapport au reste du site.
+
+## Fix
+
+Dans le layout privacy (C2), ajouter un script JSON-LD minimal :
+
+```ts
+{
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  '@id': `${BASE_URL}/${locale}/privacy#webpage`,
+  url: `${BASE_URL}/${locale}/privacy`,
+  name: locale === 'fr' ? 'Politique de confidentialité — Roget Concept' : 'Privacy Policy — Roget Concept',
+  isPartOf: { '@id': `${BASE_URL}/#website` },
+  inLanguage: locale,
+}
+```

--- a/seo-tasks/L8-low-testimonials-static-html.md
+++ b/seo-tasks/L8-low-testimonials-static-html.md
@@ -1,0 +1,20 @@
+# L8 — Rendre les témoignages en HTML statique
+
+**Severity:** Low  
+**Effort:** 1–2 heures  
+**File:** `src/components/sections/Testimonials.tsx`
+
+## Problème
+
+Les 5 témoignages sont dans un carousel JS (`'use client'`, `useState`, `setInterval`, `translateX`). Ils sont présents dans le DOM mais hors écran via CSS transform. Certains crawlers IA n'exécutent pas JavaScript — l'extraction des témoignages est donc peu fiable.
+
+Les témoignages contiennent pourtant le contenu le plus citable du site : des personnes nommées avec titre et entreprise faisant des affirmations spécifiques ("undisputed master of React", etc.).
+
+## Fix
+
+Remplacer le carousel par une grille CSS statique affichant les 5 témoignages simultanément. Tous les éléments seront dans le DOM visible, sans dépendance JS pour l'affichage. Cela :
+- Rend les témoignages fiablement accessibles aux crawlers IA
+- Réduit le bundle JS
+- Permet de convertir le composant en RSC (voir M1)
+
+Le trade-off : l'animation de défilement disparaît. C'est un choix à valider visuellement.

--- a/seo-tasks/L9-low-youtube-presence.md
+++ b/seo-tasks/L9-low-youtube-presence.md
@@ -1,0 +1,20 @@
+# L9 — Créer une présence YouTube
+
+**Severity:** Low  
+**Effort:** Élevé (création de contenu)  
+
+## Contexte
+
+Les mentions YouTube ont une corrélation de **0.737** avec les citations IA — le signal le plus fort connu pour la visibilité dans ChatGPT, Perplexity, et Google AI Overviews. Une seule vidéo technique liée au nom "François Roget" créerait une entité YouTube reconnue par les knowledge graphs des IA.
+
+## Idées de contenu
+
+- Walkthrough screen-recorded de l'article "How to Build a Dynamic Micro-Frontend Architecture in React" (15 min)
+- Démo de l'app Paniers avec explication technique
+- Session de live coding React/TypeScript
+
+## Setup recommandé
+
+- Nom de chaîne : "François Roget" ou "Roget Concept"
+- Description de chaîne : inclure le nom complet, l'URL du site, et le profil LinkedIn
+- Description de chaque vidéo : inclure `https://www.roget-concept.be`, LinkedIn, GitHub

--- a/seo-tasks/M1-medium-react-server-components.md
+++ b/seo-tasks/M1-medium-react-server-components.md
@@ -1,0 +1,26 @@
+# M1 — Convertir les sections statiques en React Server Components
+
+**Severity:** Medium  
+**Effort:** 2–4 heures  
+**Files:** `src/app/[locale]/page.tsx` + tous les composants de section
+
+## Problème
+
+Tous les composants de section utilisent `'use client'` uniquement parce qu'ils appellent `useTranslation()` (un hook de contexte React). La locale est disponible côté serveur via le segment d'URL `[locale]` — elle n'a pas besoin d'être lue depuis un contexte au moment du render.
+
+Conséquences actuelles :
+- Le HTML livré par Vercel au premier indexage de Google contient un shell quasi-vide
+- Le bundle JS client est plus lourd (toutes les sections incluses)
+- TTI et INP dégradés sur appareils lents
+
+## Fix
+
+1. Dans `src/app/[locale]/page.tsx` (server component), résoudre les traductions côté serveur et les passer en props aux composants de section
+2. Retirer `useTranslation()` et `'use client'` de : `Hero`, `Services`, `Expertise`, `Clients`, `Articles`, `ContactCTA`, `Footer`
+3. Garder `'use client'` sur : `Navbar` (état burger menu), `Testimonials` (carousel avec `useState`/`useEffect`), `LanguageProvider`
+
+## Impact attendu
+
+- Contenu visible dans le HTML SSR → indexé dès le premier passage Googlebot
+- Réduction du bundle JS client
+- Amélioration LCP et INP

--- a/seo-tasks/M2-medium-logos-webp.md
+++ b/seo-tasks/M2-medium-logos-webp.md
@@ -1,0 +1,27 @@
+# M2 — Convertir les logos PNG en WebP
+
+**Severity:** Medium  
+**Effort:** 20 minutes  
+**Files:** `public/logos/`
+
+## Problème
+
+7 des 8 logos clients sont en PNG. Seul `Tunz.webp` est au format moderne. Les plus lourds :
+
+| Fichier | Taille | Taille affichée |
+|---------|--------|-----------------|
+| `Be_Brussels.png` | 281 KB | 120×60 px |
+| `Paynovate.png` | 102 KB | 120×60 px |
+| `Worldline.png` | 83 KB | 120×60 px |
+
+Next.js Image Optimization sert déjà du WebP à la volée, mais partir d'une source optimisée réduit le temps de traitement et le stockage CDN.
+
+## Fix
+
+Convertir avec `cwebp`, `sharp`, ou Squoosh :
+
+```bash
+for f in public/logos/*.png; do cwebp -q 90 "$f" -o "${f%.png}.webp"; done
+```
+
+Aucun changement de code nécessaire si les références dans `site-data.ts` sont mises à jour pour pointer vers les `.webp`.

--- a/seo-tasks/M3-medium-paniers-icon-webp.md
+++ b/seo-tasks/M3-medium-paniers-icon-webp.md
@@ -1,0 +1,21 @@
+# M3 — Remplacer `paniers-icon.png` par WebP
+
+**Severity:** Medium  
+**Effort:** 10 minutes  
+**Files:** `public/paniers-icon.png` → `public/paniers-icon.webp`, `src/components/sections/AppShowcase.tsx`
+
+## Problème
+
+`public/paniers-icon.png` pèse **655 KB** pour une taille d'affichage de ~240 px. C'est 6× au-dessus d'un budget raisonnable.
+
+## Fix
+
+1. Convertir en WebP, cible < 80 KB :
+   ```bash
+   cwebp -q 90 public/paniers-icon.png -o public/paniers-icon.webp
+   ```
+
+2. Dans `src/components/sections/AppShowcase.tsx`, mettre à jour la référence :
+   ```tsx
+   src="/paniers-icon.webp"
+   ```

--- a/seo-tasks/M6-medium-cache-control-images.md
+++ b/seo-tasks/M6-medium-cache-control-images.md
@@ -1,0 +1,30 @@
+# M6 — Ajouter `Cache-Control` sur les images statiques
+
+**Severity:** Medium  
+**Effort:** 10 minutes  
+**File:** `vercel.json`
+
+## Problème
+
+Vercel sert les fichiers du répertoire `/public` avec un `max-age` très court par défaut (~0–1h). Les logos et icônes sont stables et ne changent pas — ils devraient être mis en cache longtemps côté navigateur pour accélérer les visites répétées.
+
+## Fix
+
+Ajouter dans le tableau `headers` de `vercel.json` :
+
+```json
+{
+  "source": "/logos/:file*",
+  "headers": [
+    { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+  ]
+},
+{
+  "source": "/:file(.*\\.(?:png|jpg|JPG|webp|svg)$)",
+  "headers": [
+    { "key": "Cache-Control", "value": "public, max-age=2592000" }
+  ]
+}
+```
+
+Note : ne pas mettre `immutable` sur le second pattern sauf si les noms de fichiers sont hashés.

--- a/seo-tasks/M8-medium-speakable-specification.md
+++ b/seo-tasks/M8-medium-speakable-specification.md
@@ -1,0 +1,24 @@
+# M8 — Ajouter `SpeakableSpecification` au schema
+
+**Severity:** Medium  
+**Effort:** 20 minutes  
+**Files:** `src/app/structured-data.ts`, composants Hero et Services
+
+## Problème
+
+`SpeakableSpecification` indique à Google quels passages d'une page sont les meilleurs candidats pour les réponses vocales et Google AI Overviews. Aucun passage n'est actuellement balisé.
+
+## Fix
+
+1. Ajouter des attributs `id` stables sur les éléments DOM cibles :
+   - Bio hero → `id="hero-bio"`
+   - Description service IT Consultancy → `id="service-consultancy"`
+   - Description service Training → `id="service-training"`
+
+2. Dans le nœud `ProfilePage` de `structured-data.ts`, ajouter :
+   ```ts
+   speakable: {
+     '@type': 'SpeakableSpecification',
+     cssSelector: ['#hero-bio', '#service-consultancy', '#service-training'],
+   },
+   ```

--- a/seo-tasks/claude.md
+++ b/seo-tasks/claude.md
@@ -1,4 +1,7 @@
+# Tâches SEO
+
 Quand tu démarres une tâche de ce répertoire, fais d'abord un plan à faire valider avant de coder.
 Une fois que le code est fait, demande une validation avant de commiter et pusher.
 Le code est considéré comme terminé sur le build passe.
 Les commits qui concernent un même changement doivent être mergés en un seul commit pour avoir un historique git propre.
+Quand tu as fini une tâche, supprime le fichier de cette tâche.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import './globals.css';
 
 const redHatDisplay = localFont({
 	src: './fonts/RedHatDisplay-Variable.woff2',
+	adjustFontFallback: 'Arial',
 });
 
 export const viewport: Viewport = {
@@ -37,6 +38,7 @@ export default async function RootLayout({
 	return (
 		<html lang={locale}>
 			<head>
+				<link rel="preconnect" href="https://miro.medium.com" />
 				<script
 					type="application/ld+json"
 					dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,6 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: 'ClaudeBot', allow: '/' },
       { userAgent: 'PerplexityBot', allow: '/' },
       { userAgent: 'Google-Extended', allow: '/' },
+      { userAgent: 'Anthropic-AI', allow: '/' },
     ],
     sitemap: 'https://www.roget-concept.be/sitemap.xml',
   }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,26 +8,44 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${BASE_URL}/en`,
       lastModified,
-      changeFrequency: 'monthly',
-      priority: 1,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en`,
+          fr: `${BASE_URL}/fr`,
+          'x-default': `${BASE_URL}/en`,
+        },
+      },
     },
     {
       url: `${BASE_URL}/fr`,
       lastModified,
-      changeFrequency: 'monthly',
-      priority: 1,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en`,
+          fr: `${BASE_URL}/fr`,
+          'x-default': `${BASE_URL}/en`,
+        },
+      },
     },
     {
       url: `${BASE_URL}/en/privacy`,
       lastModified,
-      changeFrequency: 'yearly',
-      priority: 0.3,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en/privacy`,
+          fr: `${BASE_URL}/fr/privacy`,
+        },
+      },
     },
     {
       url: `${BASE_URL}/fr/privacy`,
       lastModified,
-      changeFrequency: 'yearly',
-      priority: 0.3,
+      alternates: {
+        languages: {
+          en: `${BASE_URL}/en/privacy`,
+          fr: `${BASE_URL}/fr/privacy`,
+        },
+      },
     },
   ]
 }

--- a/src/components/sections/AppShowcase.tsx
+++ b/src/components/sections/AppShowcase.tsx
@@ -121,8 +121,9 @@ export default function AppShowcase() {
 									<div className="relative w-[80%] aspect-square mt-6">
 										<Image
 											src="/paniers-icon.png"
-											alt="Paniers app icon"
+											alt="Paniers — smart shopping list app for iPhone, iPad, Mac and Apple Watch"
 											fill
+											sizes="240px"
 											className="object-contain drop-shadow-xl"
 										/>
 									</div>

--- a/src/components/sections/Articles.tsx
+++ b/src/components/sections/Articles.tsx
@@ -32,7 +32,7 @@ export default function Articles() {
 									src={article.image}
 									alt={article.title}
 									fill
-									sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+									sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
 									className="object-cover group-hover:scale-105 transition-transform duration-500"
 								/>
 								<div className="absolute inset-0 bg-gradient-to-t from-primaryDark/40 to-transparent opacity-60" />

--- a/src/components/sections/Clients.tsx
+++ b/src/components/sections/Clients.tsx
@@ -27,6 +27,7 @@ export default function Clients() {
 								alt={company.name}
 								width={120}
 								height={60}
+								sizes="120px"
 								className="grayscale opacity-50 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-300 object-contain max-h-[60px]"
 							/>
 							<span className="text-[11px] text-rcGrey/50 group-hover:text-rcGrey text-center leading-tight transition-colors duration-300">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -21,8 +21,9 @@ export default function Hero() {
 							<div className="relative w-[72px] h-[88px] rounded-xl overflow-hidden border-2 border-secondaryLight/30 shadow-lg shadow-black/30">
 								<Image
 									src="/fro-pro.JPG"
-									alt="Fran&ccedil;ois Roget"
+									alt="Fran&ccedil;ois Roget, Senior Full Stack Developer and Architect based in Belgium"
 									fill
+									sizes="72px"
 									className="object-cover object-top"
 									priority
 								/>
@@ -106,8 +107,9 @@ export default function Hero() {
 							<div className="absolute inset-0 rounded-2xl overflow-hidden bg-gradient-to-br from-secondary to-primary">
 								<Image
 									src="/fro-pro.JPG"
-									alt="Fran&ccedil;ois Roget"
+									alt="Fran&ccedil;ois Roget, Senior Full Stack Developer and Architect based in Belgium"
 									fill
+									sizes="(max-width: 1023px) 0px, 420px"
 									className="object-cover object-top"
 									priority
 								/>

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -12,6 +12,7 @@ interface ServiceCardProps {
 	tagline: string;
 	paragraphs: string[];
 	points: string[];
+	cta?: string;
 }
 
 function ServiceCard({
@@ -22,6 +23,7 @@ function ServiceCard({
 	tagline,
 	paragraphs,
 	points,
+	cta,
 }: ServiceCardProps) {
 	return (
 		<div className="relative bg-white rounded-2xl p-10 lg:p-12 border border-rcGrey/15 shadow-[0_4px_24px_rgba(38,38,117,0.1)] hover:shadow-[0_8px_40px_rgba(38,38,117,0.18)] hover:-translate-y-1.5 hover:border-secondary/30 transition-all duration-300 overflow-hidden">
@@ -57,6 +59,14 @@ function ServiceCard({
 					</div>
 				))}
 			</div>
+			{cta && (
+				<a
+					href="#contact"
+					className="inline-flex items-center gap-2 mt-6 text-sm font-bold text-secondary hover:text-secondaryLight transition-colors"
+				>
+					{cta} →
+				</a>
+			)}
 		</div>
 	);
 }
@@ -95,6 +105,7 @@ export default function Services() {
 						tagline={t.services.training.tagline}
 						paragraphs={t.services.training.paragraphs}
 						points={t.services.training.points}
+						cta={t.services.training.cta}
 					/>
 				</div>
 			</div>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -42,7 +42,7 @@ export const en = {
 				'React & TypeScript architecture reviews and hands-on development',
 				'Fullstack integration with Java and PHP backends',
 				'Technical leadership and code quality improvement',
-				'Pragmatic, no-nonsense solutions focused on business results',
+				'Available for European remote engagements, operational from day one',
 			],
 		},
 		training: {
@@ -51,8 +51,9 @@ export const en = {
 			tagline: 'Empower your developers. Accelerate your team.',
 			paragraphs: [
 				'Tailored training sessions for modern web development with React, TypeScript, Nx, and more. From hands-on workshops to advanced architecture courses, my trainings are designed to be practical, engaging, and immediately applicable.',
-				"Whether you're onboarding juniors or upskilling seniors, I help your team grow with confidence and purpose.",
+				"Whether you're onboarding juniors or upskilling seniors, I help your team grow with confidence and purpose. Available for on-site workshops in Belgium and northern France, and remote sessions worldwide.",
 			],
+			cta: 'Get in touch about training',
 			points: [
 				'React, TypeScript and Nx workshops for all levels',
 				'Advanced architecture and micro-frontend courses',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -60,8 +60,9 @@ export const fr: Translations = {
 				'Faites monter en compétences vos développeurs. Accélérez votre équipe.',
 			paragraphs: [
 				"Des formations sur mesure pour le développement web moderne avec React, TypeScript, Nx, et plus encore. Des workshops pratiques aux cours d'architecture avancée, mes formations sont conçues pour être pratiques, engageantes et immédiatement applicables.",
-				"Que vous intégriez des juniors ou fassiez monter en compétences des seniors, j'aide votre équipe à grandir avec confiance.",
+				"Que vous intégriez des juniors ou fassiez monter en compétences des seniors, j'aide votre équipe à grandir avec confiance. Disponible pour des workshops en présentiel en Belgique et dans le nord de la France, et en remote dans le monde entier.",
 			],
+			cta: 'Me contacter pour une formation',
 			points: [
 				'Workshops React, TypeScript et Nx pour tous les niveaux',
 				"Cours avancés d'architecture et de micro-frontends",


### PR DESCRIPTION
## Summary

A batch of SEO quick wins across multiple areas:

**Images (`next/image` `sizes` prop)**
- Hero photo: correct `sizes` for mobile (72px) and desktop (420px)
- AppShowcase: `sizes="240px"`
- Clients logos: `sizes="120px"`
- Articles grid: fixed `25vw` → `33vw` (3-column layout)
- Updated alt texts to be descriptive and keyword-rich

**Sitemap (`src/app/sitemap.ts`)**
- Removed `changeFrequency` and `priority` (ignored by Google)
- Added `alternates.languages` hreflang cross-links on all 4 entries

**Copy (`src/i18n/locales/en.ts` + `fr.ts`)**
- Consultancy: replaced generic bullet with "Available for European remote engagements, operational from day one"
- Training: added "Available for on-site workshops in Belgium and northern France, and remote sessions worldwide"
- Training card: added a "Get in touch about training" CTA button

**Config (`src/app/layout.tsx`)**
- `adjustFontFallback: 'Arial'` on local font to reduce CLS during font swap
- `<link rel="preconnect" href="https://miro.medium.com" />` for article images

**Robots (`src/app/robots.ts`)**
- Explicit allow rule for `Anthropic-AI` crawler

## Test plan

- [ ] Build passes without errors
- [ ] Article images load correctly on all grid layouts
- [ ] Sitemap at `/sitemap.xml` contains `xhtml:link` hreflang entries
- [ ] Training section shows the new CTA button

🤖 Generated with [Claude Code](https://claude.com/claude-code)